### PR TITLE
add protocol option (ssh or https) in config/settings.yml

### DIFF
--- a/example_app/github_repo_helper.rb
+++ b/example_app/github_repo_helper.rb
@@ -53,7 +53,7 @@ class GithubRepoHelper
   def shell_create_and_push_commit(repo_credentials, application_name)
     private_key = repo_credentials["private_key"]
     repo_name = repo_credentials["name"]
-    repo_ssh_url = repo_credentials["ssh_url"]
+    repo_url = repo_credentials["ssh"] ? repo_credentials["ssh_url"] : repo_credentials["uri"]
     keys_dir = "/tmp/github_keys"
     key_file_name = "#{keys_dir}/#{repo_name}.key"
     git_ssh_script = "/tmp/#{repo_name}_ssh_script.sh"
@@ -87,7 +87,8 @@ BASH
     end
 
     commands = [
-        "cd /tmp; GIT_SSH=#{git_ssh_script} git clone #{repo_ssh_url} 2>&1",
+        "cd /tmp; GIT_SSH=#{git_ssh_script} git clone #{repo_url} 2>&1",
+        "cd /tmp/#{repo_name} && git config user.email '#{application_name}' 2>&1",
         "cd /tmp/#{repo_name} && git config user.name '#{application_name}' 2>&1",
         "cd /tmp/#{repo_name} && git commit --allow-empty -m 'auto generated empty commit' 2>&1",
         "cd /tmp/#{repo_name} && git log --pretty=format:\"%h%x09%ad%x09%s\" 2>&1",

--- a/service_broker/config/settings.yml
+++ b/service_broker/config/settings.yml
@@ -38,3 +38,4 @@ github:
   # curl -u <your-github-username> -d '{"scopes": ["repo", "delete_repo"], "note": "CF Service Broker"}' https://api.github.com/authorizations
   username: #<your-github-username>
   access_token: #<token-value>
+  ssh: true

--- a/service_broker/github_service_helper.rb
+++ b/service_broker/github_service_helper.rb
@@ -13,9 +13,10 @@ class GithubServiceHelper
   class GithubError < StandardError
   end
 
-  def initialize(login, access_token)
+  def initialize(login, access_token, ssh=true)
     @login = login
     @access_token = access_token
+    @ssh = ssh
   end
 
   def create_github_repo(name)
@@ -63,7 +64,8 @@ class GithubServiceHelper
         name: repo_name,
         uri: repo_https_url(full_repo_name),
         ssh_url: repo_ssh_url(full_repo_name),
-        private_key: key_pair.private_key
+        private_key: key_pair.private_key,
+        ssh: @ssh
     }
   end
 
@@ -122,7 +124,7 @@ class GithubServiceHelper
   end
 
   def repo_https_url(full_repo_name)
-    "https://github.com/#{full_repo_name}"
+    "https://#{@login}:#{@access_token}@github.com/#{full_repo_name}"
   end
 
   def octokit_client

--- a/service_broker/service_broker_app.rb
+++ b/service_broker/service_broker_app.rb
@@ -120,6 +120,6 @@ class ServiceBrokerApp < Sinatra::Base
 
   def github_service
     github_credentials = self.class.app_settings.fetch("github")
-    GithubServiceHelper.new(github_credentials.fetch("username"), github_credentials.fetch("access_token"))
+    GithubServiceHelper.new(github_credentials.fetch("username"), github_credentials.fetch("access_token"), github_credentials.fetch("ssh"))
   end
 end


### PR DESCRIPTION
The "example-app" breaks when the network (on which this app is deployed) can't use ssh port (22) for whatever reason, e.g. corporate FW setting. The error after "Create a commit" button is pressed may be as follows:

...
ssh: connect to host github.com port 22: Connection timed out
fatal: Could not read from remote repository.
...

This patch allows users to select https over ssh as git protocol if he/she likes. Also, when ssh is used, "The following SSH key was added to .." email message is coming whenever an app binds the service. It's a bit noisy in development.
