### PR TITLE
Fixed typographical error, changed adminstrator to administrator in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ bind | Generates a GitHub deploy key which gives write access to the repository,
 unbind | Destroys the deploy key bound to the service instance.
 delete | Deletes the service instance (repository).
 
-The GitHub credentials of the GitHub account adminstrator should be specified in `settings.yml` if you are deploying your own instance of this broker application. We suggest that you create a dedicated GitHub account solely for the purpose of testing this broker (since it will create and destroy repositories).
+The GitHub credentials of the GitHub account administrator should be specified in `settings.yml` if you are deploying your own instance of this broker application. We suggest that you create a dedicated GitHub account solely for the purpose of testing this broker (since it will create and destroy repositories).
 
 
 ## The Service Broker


### PR DESCRIPTION
@cloudfoundry-samples, I've corrected a typographical error in the documentation of the [github-service-broker-ruby](https://github.com/cloudfoundry-samples/github-service-broker-ruby) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.