### PR TITLE
Modify the branch name in github for push

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ With `cf`:
 $ cd github-service-broker-ruby/example_app/
 $ cf push github-consumer
 $ cf create-service github-repo public github-repo-1
-$ cf bind-service github-repo-1 github-consumer
+$ cf bind-service github-consumer github-repo-1
 $ cf services # can be used to verify the binding was created
 $ cf restart github-consumer
 ```

--- a/example_app/github_repo_helper.rb
+++ b/example_app/github_repo_helper.rb
@@ -36,10 +36,10 @@ class GithubRepoHelper
   # - configure git ssh (known hosts, and private key file)
   # - clone the repo
   # - set git author
-  # - check out master
+  # - check out main branch
   # - create empty commit
   # - print the commit log
-  # - push commit to master
+  # - push commit to main branch
   # - delete private key
   # - delete ssh script
   # - delete cloned directory
@@ -93,7 +93,7 @@ BASH
         "cd #{temp_dir}/#{repo_name} && git config user.email '#{application_name}@example.com' 2>&1",
         "cd #{temp_dir}/#{repo_name} && git commit --allow-empty -m 'auto generated empty commit' 2>&1",
         "cd #{temp_dir}/#{repo_name} && git log --pretty=format:\"%h%x09%ad%x09%s\" 2>&1",
-        "cd #{temp_dir}/#{repo_name}; GIT_SSH=#{git_ssh_script} git push origin master 2>&1"
+        "cd #{temp_dir}/#{repo_name}; GIT_SSH=#{git_ssh_script} git push origin main 2>&1"
     ]
 
     return_code = 0


### PR DESCRIPTION
The default branch name in github seems to have been changed from `master` to `main`. This modification is to align with that.

https://github.com/github/renaming

And also, I've found a mistake in the instruction of README, so that tiny modification is also included.