### PR TITLE
cf bind-service command arguments incorrect order

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ With `cf`:
 $ cd github-service-broker-ruby/example_app/
 $ cf push github-consumer
 $ cf create-service github-repo public github-repo-1
-$ cf bind-service github-repo-1 github-consumer
+$ cf bind-service github-consumer github-repo-1
 $ cf services # can be used to verify the binding was created
 $ cf restart github-consumer
 ```


### PR DESCRIPTION
- cf bind-service APP_NAME SERVICE_INSTANCE suggests that
`github-consumer` should come before `github-repo-1`.